### PR TITLE
Fix infinite loop on CookingLogic pausing

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/cooking/CookingLogic.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedcore/upgrades/cooking/CookingLogic.java
@@ -44,6 +44,8 @@ public class CookingLogic<T extends AbstractCookingRecipe> {
 	private long remainingCookTime = 0;
 	private long remainingBurnTime = 0;
 
+	private boolean inPause = false;
+
 	public CookingLogic(ItemStack upgrade, Consumer<ItemStack> saveHandler, CookingUpgradeConfig cookingUpgradeConfig, RecipeType<T> recipeType, float burnTimeModifier) {
 		this(upgrade, saveHandler, s -> getBurnTime(s, burnTimeModifier) > 0, s -> RecipeHelper.getCookingRecipe(s, recipeType).isPresent(), cookingUpgradeConfig, recipeType, burnTimeModifier);
 	}
@@ -204,10 +206,18 @@ public class CookingLogic<T extends AbstractCookingRecipe> {
 	}
 
 	public void pause() {
-		paused = true;
-		setCookTimeFinish(0);
-		setIsCooking(false);
-		setBurnTimeFinish(0);
+		if (inPause) {
+			return;
+		}
+		inPause = true;
+		try {
+			paused = true;
+			setCookTimeFinish(0, false);
+			setIsCooking(false);
+			setBurnTimeFinish(0);
+		} finally {
+			inPause = false;
+		}
 	}
 
 	private void updateFuel(Level level, T cookingRecipe) {
@@ -311,8 +321,14 @@ public class CookingLogic<T extends AbstractCookingRecipe> {
 	}
 
 	private void setCookTimeFinish(long cookTimeFinish) {
+		setCookTimeFinish(cookTimeFinish, true);
+	}
+
+	private void setCookTimeFinish(long cookTimeFinish, boolean shouldSave) {
 		upgrade.sophisticatedCore_set(ModCoreDataComponents.COOK_TIME_FINISH, cookTimeFinish);
-		save();
+		if (shouldSave) {
+			save();
+		}
 	}
 
 	public int getCookTimeTotal() {


### PR DESCRIPTION
Hey, I have recently encountered a crash with CookingLogic's pausing on my 1.21.1 fabric server and here is a potential fix

- Add `inPause` state to check and avoid nested pasuing
- Add `shouldSave` flag to avoid dupe calls

It's a StackOverflowError caused by infinite loop on saving/pausing

```
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.pause(CookingLogic.java:208) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingUpgradeWrapper.pauseAndRemoveRenderInfo(CookingUpgradeWrapper.java:62) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingUpgradeWrapper.onBeforeRemoved(CookingUpgradeWrapper.java:58) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler.setStackInSlot(UpgradeHandler.java:191) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler.lambda$initializeWrappers$3(UpgradeHandler.java:129) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.save(CookingLogic.java:63) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.setCookTimeFinish(CookingLogic.java:315) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.pause(CookingLogic.java:208) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingUpgradeWrapper.pauseAndRemoveRenderInfo(CookingUpgradeWrapper.java:62) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingUpgradeWrapper.onBeforeRemoved(CookingUpgradeWrapper.java:58) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler.setStackInSlot(UpgradeHandler.java:191) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler.lambda$initializeWrappers$3(UpgradeHandler.java:129) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.save(CookingLogic.java:63) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.setCookTimeFinish(CookingLogic.java:315) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.pause(CookingLogic.java:208) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingUpgradeWrapper.pauseAndRemoveRenderInfo(CookingUpgradeWrapper.java:62) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingUpgradeWrapper.onBeforeRemoved(CookingUpgradeWrapper.java:58) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler.setStackInSlot(UpgradeHandler.java:191) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler.lambda$initializeWrappers$3(UpgradeHandler.java:129) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.save(CookingLogic.java:63) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.setCookTimeFinish(CookingLogic.java:315) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.pause(CookingLogic.java:208) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingUpgradeWrapper.pauseAndRemoveRenderInfo(CookingUpgradeWrapper.java:62) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingUpgradeWrapper.onBeforeRemoved(CookingUpgradeWrapper.java:58) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler.setStackInSlot(UpgradeHandler.java:191) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler.lambda$initializeWrappers$3(UpgradeHandler.java:129) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.save(CookingLogic.java:63) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.setCookTimeFinish(CookingLogic.java:315) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
at knot/net.p3pp3rf1y.sophisticatedcore.upgrades.cooking.CookingLogic.pause(CookingLogic.java:208) ~[sophisticatedcore-1.21.1-1.2.9.17.157.jar:?]
```